### PR TITLE
Major: Updated hostnet/phpcs-tool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,8 @@ services:
     - mysql
 
 php:
-    - 5.6
-    - 7.0
     - 7.1
+    - 7.2
     - nightly
 
 matrix:

--- a/composer.json
+++ b/composer.json
@@ -4,11 +4,11 @@
     "description": "Provide a real database, safe for testing purposes",
     "license":     "MIT",
     "require": {
-        "php":          "^5.6|^7.0",
+        "php":          ">=7.1",
         "doctrine/orm": "^2.5.4"
     },
     "require-dev": {
-        "hostnet/phpcs-tool": "^4.0.6",
+        "hostnet/phpcs-tool": "^6.0.2",
         "phpunit/phpunit":    "^5.3.2"
     },
     "autoload": {

--- a/src/ConnectionInterface.php
+++ b/src/ConnectionInterface.php
@@ -2,6 +2,8 @@
 /**
  * @copyright 2016-2017 Hostnet B.V.
  */
+declare(strict_types=1);
+
 namespace Hostnet\Component\DatabaseTest;
 
 /**

--- a/src/MysqlPersistentConnection.php
+++ b/src/MysqlPersistentConnection.php
@@ -2,6 +2,8 @@
 /**
  * @copyright 2016-2017 Hostnet B.V.
  */
+declare(strict_types=1);
+
 namespace Hostnet\Component\DatabaseTest;
 
 /**
@@ -69,10 +71,12 @@ class MysqlPersistentConnection implements ConnectionInterface
         $this->pipe = $pipes[0];
 
         foreach (explode(',', $data) as $param) {
-            if (strpos($param, ':') !== false) {
-                list($key, $value)                   = explode(':', $param);
-                $this->connection_params[trim($key)] = trim($value);
+            if (strpos($param, ':') === false) {
+                continue;
             }
+
+            list($key, $value)                   = explode(':', $param);
+            $this->connection_params[trim($key)] = trim($value);
         }
     }
 

--- a/test/MysqlPersistentConnectionTest.php
+++ b/test/MysqlPersistentConnectionTest.php
@@ -2,6 +2,8 @@
 /**
  * @copyright 2016-2017 Hostnet B.V.
  */
+declare(strict_types=1);
+
 namespace Hostnet\Component\DatabaseTest;
 
 use Doctrine\DBAL\DriverManager;


### PR DESCRIPTION
- Updated hostnet/phpcs-tool
- Dropped PHP5.6 and PHP7.0 support

This should probably be a major because we only support `>= PHP7.1` after this commit.