### PR TITLE
Upgrade deprecated actions/cache in workflow to v4

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,8 +21,9 @@ jobs:
             php-version: ${{ matrix.php-versions }}
       -   name: Get composer cache directory
           id: composer-cache
-          run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-      -   uses: actions/cache@v2
+          run: |
+              echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      -   uses: actions/cache@v4
           with:
             path: ${{ steps.composer-cache.outputs.dir }}
             key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}


### PR DESCRIPTION
Upgraded actions/cache to v4 in accordance with notice of v1/v2 package closing down.

https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down